### PR TITLE
Have theme extract to themes folder of site not tmp

### DIFF
--- a/inc/class-command.php
+++ b/inc/class-command.php
@@ -14,7 +14,7 @@ class Command {
 
 	/*
 	 * Empty array that holds transformed slug and other replacements
-	 *
+	 * 
 	 * @var array
 	 */
 	protected $replace = [];
@@ -74,24 +74,25 @@ class Command {
 	 */
 	public function __invoke( $args, $assoc_args ) {
 
-		$this->replace           = $this->split( sanitize_text_field( $args[0] ) );
-		$this->replace['author'] = sanitize_text_field( $assoc_args['author'] );
+		$this->replace = $this->split( sanitize_text_field( $args[0] ));
+		$this->replace['author']  = sanitize_text_field( $assoc_args['author'] );
 		$this->replace['uri']    = esc_url_raw( $assoc_args['uri'] );
 
 		// Extract The Genesis Sample zip file into /tmp/<theme-slug>.
 		$this->file = new Zipper( $this->replace['slug'] );
-		$this->path = '/tmp/' . $this->replace['slug'];
+		$this->path = get_theme_root() . '/' . $this->replace['slug'];
 
 		// Make sure our file exists before continuing on.
-		if ( file_exists( $this->path ) ) {
-
+		if ( file_exists( $this->path ) ) 
+		{
 			\WP_CLI::log( 'Folder exists. Continuing.' );
 
 			// Call our Iterator to open the files and perform the string replace on the filesystem
 			new Iterator( $this->replace, $this->path );
+
 		}
 
-		\WP_CLI::success( $this->author . ' ' . $this->uri );
+		\WP_CLI::success("Created new theme: " );
 	}
 	/**
 	 * Returns an array for slug, full

--- a/inc/class-iterator.php
+++ b/inc/class-iterator.php
@@ -29,7 +29,7 @@ class Iterator {
 		'StudioPress',
 	];
 	/**
-	 * This stores the replaced string to set.
+	 * This stores the replaced string to set. 
 	 *
 	 * @var string
 	 */
@@ -40,7 +40,7 @@ class Iterator {
 	 * @var array
 	 */
 	protected $replace;
-
+	
 	public function __construct( array $slug, string $path ) {
 
 		$this->open( $slug, $path );
@@ -49,7 +49,7 @@ class Iterator {
 	/**
 	 * Opens all the files for the theme and calls the replace function
 	 *
-	 * @param array  $slug
+	 * @param array $slug
 	 * @param string $path
 	 * @return void
 	 */
@@ -69,15 +69,16 @@ class Iterator {
 					$this->meta = $this->replace_genesis( $slug, $this->file );
 					$this->file = file_put_contents( $iterator->getPathname(), $this->meta );
 				} else {
-
+					
 				}
 			}
+			copy( $path, get_theme_direcotry() . $slug);
 		}
 	}
 	/**
 	 * Replaces all references from $search with $replace
 	 *
-	 * @param array  $replace The array of strings to replace
+	 * @param array $replace The array of strings to replace
 	 * @param string $file The string to run function on
 	 * @return string
 	 */

--- a/inc/class-zipper.php
+++ b/inc/class-zipper.php
@@ -17,10 +17,10 @@ class Zipper {
 		$result = $zip->open( $this->tmp );
 
 		if ( $result ) {
-			$zip->extractTo("/tmp");
+			$zip->extractTo( get_theme_root() );
 			$zip->close();
-			unlink( $$this->tmp );
-			$rename = rename( '/tmp/genesis-sample-master/', '/tmp' . '/' . $slug );
+			
+			$rename = rename( get_theme_root() . '/genesis-sample-master', get_theme_root() . '/' . $slug );
 			if ( $rename ) {
 				\WP_CLI::log( "Renamed temp directory") ;
 			}


### PR DESCRIPTION
This fixes a bug where the theme was being sent to /tmp rather than the WordPress theme directory.